### PR TITLE
Make script work again

### DIFF
--- a/create_initramfs.sh
+++ b/create_initramfs.sh
@@ -32,7 +32,7 @@ urandom_url="https://raw.githubusercontent.com/buildroot/buildroot/master/packag
 passwd_url="https://raw.githubusercontent.com/buildroot/buildroot/master/system/skeleton/etc/passwd"
 shadow_url="https://raw.githubusercontent.com/buildroot/buildroot/master/system/skeleton/etc/shadow"
 group_url="https://raw.githubusercontent.com/buildroot/buildroot/master/system/skeleton/etc/group"
-fstab_url="https://raw.githubusercontent.com/buildroot/buildroot/master/system/skeleton/etc/fstab"
+fstab_url="https://raw.githubusercontent.com/buildroot/buildroot/76fc9275f14ec295b0125910464969bfa7441b85/package/skeleton-sysv/skeleton/etc/fstab"
 inittab_url="https://raw.githubusercontent.com/buildroot/buildroot/master/package/busybox/inittab"
 
 # Get the distro we're running on

--- a/create_initramfs.sh
+++ b/create_initramfs.sh
@@ -136,20 +136,20 @@ done
 
 # Get a busybox RPM from Fedora
 if [[ "${ARCH}" == "ppc64" ]] ; then
-	pkg=busybox-1.22.1-4.fc23.ppc64.rpm
+	pkg=busybox-1.26.2-3.fc27.ppc64.rpm
 	pkgurl=${pkgurl:-https://dl.fedoraproject.org/pub/fedora-secondary/releases/23/Everything/ppc64/os/Packages/b/}${pkg}
 elif [[ "${ARCH}" == "ppc64le" ]] ; then
-	pkg=busybox-1.22.1-4.fc23.ppc64le.rpm
-	pkgurl=https://dl.fedoraproject.org/pub/fedora-secondary/releases/23/Everything/ppc64le/os/Packages/b/$pkg
+	pkg=busybox-1.26.2-3.fc27.ppc64le.rpm
+	pkgurl=https://dl.fedoraproject.org/pub/fedora-secondary/releases/28/Everything/ppc64le/os/Packages/b/$pkg
 elif [[ "${ARCH}" == "i386" ]] ; then
 	pkg=busybox-1.22.1-4.fc23.i686.rpm
 	pkgurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/23/Everything/i386/os/Packages/b/${pkg}
 elif [[ "${ARCH}" == "x86_64" ]] ; then
-	pkg=busybox-1.22.1-4.fc23.x86_64.rpm
-	pkgurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/23/Everything/x86_64/os/Packages/b/${pkg}
+	busybox-1.26.2-3.fc27.x86_64.rpm
+	pkgurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/b/${pkg}
 elif [[ "${ARCH}" == "arm" ]] ; then
-	pkg=busybox-1.22.1-4.fc23.armv7hl.rpm
-	pkgurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/23/Everything/armhfp/os/Packages/b/${pkg}
+	pkg=busybox-1.26.2-3.fc27.armv7hl.rpm
+	pkgurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/armhfp/os/Packages/b/${pkg}
 else
 	usage
 fi


### PR DESCRIPTION
When I used the script, I faced two problems:
* The fstab URL is broken (mentioned in #2).
* The busybox URLs are outdated.

I fixed URLs except the one which belongs to busybox for the i386 port. Fedora doesn't support the port anymore, so I guess you should consider either removing the support of i386 from the script or fetching it from a different place.

At least a couple of your articles[[1]](https://blog.christophersmart.com/2016/10/27/building-and-booting-upstream-linux-and-u-boot-for-raspberry-pi-23-arm-boards/)[[2]](https://blog.christophersmart.com/2016/10/23/building-and-booting-upstream-linux-and-u-boot-for-orange-pi-one-arm-board/) reference to the script, so I think it's quite important to fix it.

Fixes #2.

