### PR TITLE
Fix script for arch

### DIFF
--- a/create_initramfs.sh
+++ b/create_initramfs.sh
@@ -168,7 +168,7 @@ cp "${CACHE_DIR}/${pkg}" .
 
 # Extract rpm to get busybox binary
 if [[ "${ID}" == "arch" ]]; then
-	rpm2cpio ${pkg} |xv -d |cpio -idm 2>/dev/null
+	rpm2cpio ${pkg} |xz -d |cpio -idm 2>/dev/null
 else
 	rpm2cpio ${pkg} |cpio -idm 2>/dev/null
 fi


### PR DESCRIPTION
Looks like a typo.  Also, if this was for arch since arch has bleeding edge packages, it's probably not a bad idea to check for what exactly the cause is (rpm2cpio versions?) instead of just the distro.